### PR TITLE
Feat: Added LLM model-selection UI & multi-client support

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,12 +9,19 @@ from openai import OpenAI
 from dotenv import load_dotenv
 import streamlit as st
 from pathlib import Path
+import anthropic
 
 load_dotenv(override = 'TRUE')
 api_key = os.getenv("OPENAI_API_KEY")
+anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
+
+# Load LLM SDK clients
+openai_client = OpenAI(api_key=api_key)
+claude_client = anthropic.Anthropic(api_key=anthropic_api_key)
+ollama_via_openai = OpenAI(base_url="http://localhost:11434/v1", api_key="ollama")
 
 st.set_page_config(page_title="Book QA", layout="wide")
-st.title("Choose a Book and Ask a Question")
+st.title("Choose your Model, Book and Ask a Question")
 
 @st.cache_resource
 def load_vectordb(pdf_path: str, persist_dir: str):
@@ -27,17 +34,7 @@ def load_vectordb(pdf_path: str, persist_dir: str):
         filtered = lines
         raw_pages.append("\n".join(filtered))
 
-    # # 2) Split per page with metadata
-    # splitter = CharacterTextSplitter(
-    #     separator="\n", chunk_size=1500, chunk_overlap=200, length_function=len
-    # )
-    # texts, metadatas = [], []
-    # for i, pg in enumerate(raw_pages, start=1):
-    #     for chunk in splitter.split_text(pg):
-    #         texts.append(chunk)
-    #         metadatas.append({"page": i})
-
-        # 2) Treat each page as one chunk
+    # 2) Treat each page as one chunk
     texts = raw_pages
     metadatas = [{"page": i} for i in range(1, len(raw_pages) + 1)]
 
@@ -81,12 +78,17 @@ else:
 book_stem = Path(selected_pdf).stem
 persist_dir = f"faiss_book_index_{book_stem}"
 vectordb = load_vectordb(selected_pdf, persist_dir)
-llm_client = get_llm()
 
+# Model selection
+st.header("Model Selection")
+model_option = st.selectbox(
+    "Choose a model:",
+    ["gpt-4o-mini", "claude-3-haiku-20240307", "llama3.2", "mistral:7b"]
+)
 
 system_prompt = "You are a helpful assistant. Answer the question using ONLY the provided excerpts—quote verbatim and cite page numbers."
 
-def answer_question(query: str, k: int = 10) -> str:
+def answer_question(query: str, model_option: str, k: int = 10) -> str:
     # 1) fetch top-k chunks
     docs = vectordb.similarity_search(query, k=k)
 
@@ -107,12 +109,34 @@ def answer_question(query: str, k: int = 10) -> str:
         {"role": "system", "content": system_prompt},
         {"role": "user",   "content": user_prompt},
     ]
-    resp = llm_client.chat.completions.create(
-        model="gpt-4o-mini",
-        messages=messages,
-        temperature=0.0,
-    )
-    answer = resp.choices[0].message.content
+
+    # Call appropriate LLM based on selected model
+    if model_option == "gpt-4o-mini":
+        resp = openai_client.chat.completions.create(
+            model=model_option,
+            messages=messages,
+            temperature=0.0,
+        )
+        answer = resp.choices[0].message.content
+    
+    elif model_option.startswith("claude"):  # Claude-style API
+        claude_messages = [{"role": "user", "content": user_prompt}]
+        resp = claude_client.messages.create(
+            model=model_option,
+            system=system_prompt,
+            messages=claude_messages,
+            max_tokens=1000,
+        )
+        answer = resp.content[0].text
+    
+    else:  # llama3.2 or mistral:7b via Ollama server
+        resp = ollama_via_openai.chat.completions.create(
+            model=model_option,
+            messages=messages,
+            temperature=0.0,
+        )
+        answer = resp.choices[0].message.content
+
     # collect the page numbers to return alongside the text
     pages = [doc.metadata.get("page", "?") for doc in docs]
     return answer, pages
@@ -124,9 +148,8 @@ st.header("Ask the Book 📖")
 with st.form(key="qa_form"):
     question = st.text_input("Your question:")
     submit  = st.form_submit_button("Ask")
-
 if submit and question:
-    answer, pages = answer_question(question)
+    answer, pages = answer_question(question,model_option)
     st.subheader("Answer")
     st.write(answer)
     st.markdown(f"**Referenced pages:** {', '.join(map(str, pages))}")


### PR DESCRIPTION
**What’s Changed**

- Model Selection UI: Added a “Model Selection” header + dropdown for four backends (gpt-4o-mini, claude-3-haiku, llama3.2, mistral:7b).
- Multi-Client Setup: Instantiated separate SDK clients (openai_client, claude_client, ollama_via_openai) instead of one hard-coded client.
- Dynamic Dispatch: answer_question(...) now routes requests based on the selected model.
- Cleanup: Removed the old get_llm helper and unused imports.

**Why**

- Experiment with different LLMs on the fly.
- Keep each client’s code path isolated and easier to extend.